### PR TITLE
cli commit: index.js, Player.js, utils.js — 3 files changed, 25 inserti…

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,10 @@ function animate() {
         })
     }
     if (enemyMatch) {
-        enemyMatch.forEach(x => x.draw(2))
+        enemyMatch.forEach(x => {
+            x.draw(2)
+            x.update()
+        })
     }
 
     player.draw(2);

--- a/js/classes/Player.js
+++ b/js/classes/Player.js
@@ -74,7 +74,7 @@ class Player extends Sprite {
             this.checkDiamondHitCollision()
         }
 
-        if (enemies?.length) {
+        if (enemies?.length || enemyKing?.length || enemyMatch?.length) {
             this.checkEnemyContactDamage()
         }
 
@@ -287,18 +287,23 @@ class Player extends Sprite {
     checkEnemyContactDamage() {
         if (this.dead || this.hitCooldown) return
 
-        for (let i = 0; i < enemies.length; i++) {
-            const enemy = enemies[i]
-            if (!enemy.loaded || !enemy.opacity || enemy.hitpoints <= 0) continue
+        const groups = [enemies, enemyKing, enemyMatch]
+        for (let g = 0; g < groups.length; g++) {
+            const group = groups[g]
+            if (!group?.length) continue
+            for (let i = 0; i < group.length; i++) {
+                const enemy = group[i]
+                if (!enemy.loaded || !enemy.opacity || enemy.hitpoints <= 0) continue
 
-            const e = enemy.hitbox
-            const p = this.hitbox
-            if (p.position.x + p.width >= e.position.x &&
-                p.position.x <= e.position.x + e.width &&
-                p.position.y + p.height >= e.position.y &&
-                p.position.y <= e.position.y + e.height) {
-                this.takeContactDamageFromEnemy(enemy)
-                return
+                const e = enemy.hitbox
+                const p = this.hitbox
+                if (p.position.x + p.width >= e.position.x &&
+                    p.position.x <= e.position.x + e.width &&
+                    p.position.y + p.height >= e.position.y &&
+                    p.position.y <= e.position.y + e.height) {
+                    this.takeContactDamageFromEnemy(enemy)
+                    return
+                }
             }
         }
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -314,10 +314,11 @@ async function createAssets(level, options = {}) {
         levelWidth
     }
 }
-function applyCollisions(player, enemies, enemyKing, collisionBlocks) {
+function applyCollisions(player, enemies, enemyKing, enemyMatch, collisionBlocks) {
     player.collisionBlocks = collisionBlocks
     enemies.forEach(enemy => enemy.collisionBlocks = collisionBlocks)
     enemyKing.forEach(king => king.collisionBlocks = collisionBlocks)
+    enemyMatch.forEach(match => match.collisionBlocks = collisionBlocks)
 }
 async function initializeLevel(level, playerPosition, lastDirection, options = {}) {
     ({ boxes, platforms, doors, enemies, collisionBlocks, enemyKing, background, diamonds, platformsBlocks, levelWidth, cannon, enemyMatch } = await createAssets(level, options));
@@ -327,7 +328,7 @@ async function initializeLevel(level, playerPosition, lastDirection, options = {
         platforms.flatMap(platform => platform.collisionBlocks)
     );
 
-    applyCollisions(player, enemies, enemyKing, collisionBlocks);
+    applyCollisions(player, enemies, enemyKing, enemyMatch, collisionBlocks);
 
     if (player.contactDamageTimeoutId) {
         clearTimeout(player.contactDamageTimeoutId)


### PR DESCRIPTION
Opened automatically after a Cursor CLI run from the WhatsApp bot.

**Branch:** `cursor/issue-5-contact-damage-extend-to-king-match-enemies-igno`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #5

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/5
**State:** OPEN
**Title:** Contact damage: extend to king & match enemies + ignore dead/fading

## Body
## Parent

#1

## What to build

Extend the existing contact-damage flow so it applies consistently to **all enemy variants currently present** (`enemies`, `enemyKing`, `enemyMatch`). Ensure dead/fading/inactive enemies cannot cause “ghost” contact hits.

## Acceptance criteria

- [ ] Contact damage triggers for overlaps with all enemy collections used by the game (standard, king, match).
- [ ] Contact damage does **not** trigger for enemies that are dead/fading/inactive (e.g. hitpoints 0 and/or opacity 0 / not loaded).
- [ ] Match enemies participate reliably in contact checks (their hitbox is kept up-to-date for collision testing).

## Blocked by

- Blocked by #2