### PR TITLE
feat: Contact damage: extend to king & match enemies + ignore dea… (#5)

### DIFF
--- a/js/classes/Enemy.js
+++ b/js/classes/Enemy.js
@@ -1,7 +1,8 @@
 class Enemy extends Sprite {
-    constructor({ position, collisionBlocks = [], imageSrc, frameRate, frameBuffer, animations, loop, spawnTrack }) {
+    constructor({ position, collisionBlocks = [], imageSrc, frameRate, frameBuffer, animations, loop, spawnTrack, enemyVariant = 'pig' }) {
         super({ position, imageSrc, frameRate, animations, frameBuffer,loop })
         this.spawnTrack = spawnTrack || null
+        this.enemyVariant = enemyVariant
         this.state = 'idle'
         this.velocity = {
             x: 0,
@@ -141,13 +142,27 @@ class Enemy extends Sprite {
     }
 
     updateHitbox() {
+        if (!this.loaded) {
+            this.hitbox = {
+                position: { x: this.position.x, y: this.position.y },
+                width: 0,
+                height: 0
+            }
+            return
+        }
+        const configs = {
+            pig: { ox: 23, oy: 30, w: 37, h: 28 },
+            king: { ox: 24, oy: 30, w: 38, h: 28 },
+            match: { ox: 6, oy: 8, w: 20, h: 12 }
+        }
+        const cfg = configs[this.enemyVariant] || configs.pig
         this.hitbox = {
             position: {
-                x: this.position.x + 23,
-                y: this.position.y + 30
+                x: this.position.x + cfg.ox,
+                y: this.position.y + cfg.oy
             },
-            width: 37,
-            height: 28
+            width: cfg.w,
+            height: cfg.h
         }
     }
 

--- a/js/classes/Player.js
+++ b/js/classes/Player.js
@@ -293,7 +293,7 @@ class Player extends Sprite {
             if (!group?.length) continue
             for (let i = 0; i < group.length; i++) {
                 const enemy = group[i]
-                if (!enemy.loaded || !enemy.opacity || enemy.hitpoints <= 0) continue
+                if (!enemy.loaded || enemy.hitpoints <= 0 || enemy.opacity < 1) continue
 
                 const e = enemy.hitbox
                 const p = this.hitbox

--- a/js/utils.js
+++ b/js/utils.js
@@ -166,6 +166,7 @@ function createEnemies(positions, levelNum) {
 function createEnemiesWithMatch(positions, levelNum) {
     return positions.map(position => new Enemy({
         position: { x: position[0], y: position[1] - 5 },
+        enemyVariant: 'match',
         spawnTrack: { levelId: levelNum, kind: 'match', spawnX: position[0], spawnY: position[1] },
         imageSrc: './Sprites/07-Pig With a Match/Match On (26x18).png',
         frameRate: 3,
@@ -197,6 +198,7 @@ function createEnemiesWithMatch(positions, levelNum) {
 function createEnemyKing(positions, levelNum) {
     return positions.map(position => new Enemy({
         position: { x: position[0], y: position[1] },
+        enemyVariant: 'king',
         spawnTrack: { levelId: levelNum, kind: 'king', spawnX: position[0], spawnY: position[1] },
         imageSrc: './Sprites/02-King Pig/Idle (38x28).png',
         frameRate: 12,


### PR DESCRIPTION
Fixes #5

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-5-contact-damage-extend-to-king-match-enemies-igno-2545`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #5

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/5
**State:** OPEN
**Title:** Contact damage: extend to king & match enemies + ignore dead/fading

## Body
## Parent

#1

## What to build

Extend the existing contact-damage flow so it applies consistently to **all enemy variants currently present** (`enemies`, `enemyKing`, `enemyMatch`). Ensure dead/fading/inactive enemies cannot cause “ghost” contact hits.

## Acceptance criteria

- [ ] Contact damage triggers for overlaps with all enemy collections used by the game (standard, king, match).
- [ ] Contact damage does **not** trigger for enemies that are dead/fading/inactive (e.g. hitpoints 0 and/or opacity 0 / not loaded).
- [ ] Match enemies participate reliably in contact checks (their hitbox is kept up-to-date for collision testing).

## Blocked by

- Blocked by #2