### PR TITLE
feat: Add lightweight tests for contact-damage helpers (overlap, … (#6)

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,26 +25,27 @@
     }
   </style>
   <canvas></canvas>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.11.1/gsap.min.js" integrity="sha512-Mf/xUqfWvDIr+1B6zfnIDIiG7XHzyP/guXUWgV6PgaQoIFeXkJQR5XWh9fqAiCiRCpemabt3naV4jhDWVnuYDQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="js/utils.js"></script>
-  <script src="config/levels.js"></script>
-  <script src="js/EnemyTracker.js"></script>
-  <script src="js/audio.js"></script>
-  <script src="js/classes/Sprite.js"></script>
-  <script src="js/classes/CollisionBlock.js"></script>
-  <script src="js/data/parseAssets.js"></script>
-  <script src="js/classes/Player.js"></script>
-  <script src="js/classes/Cannon.js"></script>
-  <script src="js/classes/CannonBall.js"></script>
-  <script src="js/classes/Enemy.js"></script>
-  <script src="js/classes/DialogBox.js"></script>
-  <script src="js/classes/Diamond.js"></script>
-  <script src="js/classes/Box.js"></script>
-  <script src="js/classes/BrokenPiece.js"></script>
-  <script src="js/classes/Platform.js"></script>
-  <script src="js/eventListeners.js"></script>
-  <script src="index.js"></script>
-  <script src="config/ui.js"></script>
+  <script defer type="module" src="js/contactDamage-bootstrap.mjs"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.11.1/gsap.min.js" integrity="sha512-Mf/xUqfWvDIr+1B6zfnIDIiG7XHzyP/guXUWgV6PgaQoIFeXkJQR5XWh9fqAiCiRCpemabt3naV4jhDWVnuYDQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script defer src="js/utils.js"></script>
+  <script defer src="config/levels.js"></script>
+  <script defer src="js/EnemyTracker.js"></script>
+  <script defer src="js/audio.js"></script>
+  <script defer src="js/classes/Sprite.js"></script>
+  <script defer src="js/classes/CollisionBlock.js"></script>
+  <script defer src="js/data/parseAssets.js"></script>
+  <script defer src="js/classes/Player.js"></script>
+  <script defer src="js/classes/Cannon.js"></script>
+  <script defer src="js/classes/CannonBall.js"></script>
+  <script defer src="js/classes/Enemy.js"></script>
+  <script defer src="js/classes/DialogBox.js"></script>
+  <script defer src="js/classes/Diamond.js"></script>
+  <script defer src="js/classes/Box.js"></script>
+  <script defer src="js/classes/BrokenPiece.js"></script>
+  <script defer src="js/classes/Platform.js"></script>
+  <script defer src="js/eventListeners.js"></script>
+  <script defer src="index.js"></script>
+  <script defer src="config/ui.js"></script>
 </body>
 
 </html>

--- a/js/classes/Player.js
+++ b/js/classes/Player.js
@@ -285,7 +285,7 @@ class Player extends Sprite {
     }
 
     checkEnemyContactDamage() {
-        if (this.dead || this.hitCooldown) return
+        if (ContactDamageHelpers.cannotTakeContactDamage({ dead: this.dead, hitCooldown: this.hitCooldown })) return
 
         const groups = [enemies, enemyKing, enemyMatch]
         for (let g = 0; g < groups.length; g++) {
@@ -297,10 +297,7 @@ class Player extends Sprite {
 
                 const e = enemy.hitbox
                 const p = this.hitbox
-                if (p.position.x + p.width >= e.position.x &&
-                    p.position.x <= e.position.x + e.width &&
-                    p.position.y + p.height >= e.position.y &&
-                    p.position.y <= e.position.y + e.height) {
+                if (ContactDamageHelpers.rectHitboxesOverlap(p, e)) {
                     this.takeContactDamageFromEnemy(enemy)
                     return
                 }
@@ -316,9 +313,11 @@ class Player extends Sprite {
 
         if (!this.dead) {
             const knockbackSpeed = 10
-            const playerCx = this.hitbox.position.x + this.hitbox.width / 2
-            const enemyCx = enemyForKnockback.hitbox.position.x + enemyForKnockback.hitbox.width / 2
-            this.velocity.x = playerCx < enemyCx ? -knockbackSpeed : knockbackSpeed
+            this.velocity.x = ContactDamageHelpers.contactKnockbackVelocityX(
+                this.hitbox,
+                enemyForKnockback.hitbox,
+                knockbackSpeed
+            )
             this.velocity.y = Math.min(this.velocity.y, -4)
         }
 

--- a/js/contactDamage-bootstrap.mjs
+++ b/js/contactDamage-bootstrap.mjs
@@ -1,0 +1,3 @@
+import * as ContactDamageHelpers from './contactDamageHelpers.mjs'
+
+globalThis.ContactDamageHelpers = ContactDamageHelpers

--- a/js/contactDamageHelpers.mjs
+++ b/js/contactDamageHelpers.mjs
@@ -1,0 +1,26 @@
+/**
+ * Pure helpers for contact damage (overlap, cooldown gate, knockback direction).
+ * Used by the game via contactDamage-bootstrap.mjs and covered by node:test.
+ */
+
+/** Axis-aligned rectangle with position { x, y }, width, height */
+export function rectHitboxesOverlap(a, b) {
+    return (
+        a.position.x + a.width >= b.position.x &&
+        a.position.x <= b.position.x + b.width &&
+        a.position.y + a.height >= b.position.y &&
+        a.position.y <= b.position.y + b.height
+    )
+}
+
+/** True while overlap must not apply contact damage (cooldown after a hit, or dead). */
+export function cannotTakeContactDamage({ dead, hitCooldown }) {
+    return Boolean(dead || hitCooldown)
+}
+
+/** Horizontal knockback away from the enemy center (matches Player logic). */
+export function contactKnockbackVelocityX(playerHitbox, enemyHitbox, knockbackSpeed = 10) {
+    const playerCx = playerHitbox.position.x + playerHitbox.width / 2
+    const enemyCx = enemyHitbox.position.x + enemyHitbox.width / 2
+    return playerCx < enemyCx ? -knockbackSpeed : knockbackSpeed
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "platformer-game",
+  "private": true,
+  "scripts": {
+    "test": "node --test 'test/**/*.test.mjs'"
+  }
+}

--- a/test/contactDamageHelpers.test.mjs
+++ b/test/contactDamageHelpers.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+    cannotTakeContactDamage,
+    contactKnockbackVelocityX,
+    rectHitboxesOverlap,
+} from '../js/contactDamageHelpers.mjs'
+
+test('rectHitboxesOverlap: separated on x', () => {
+    const a = { position: { x: 0, y: 0 }, width: 10, height: 10 }
+    const b = { position: { x: 20, y: 0 }, width: 10, height: 10 }
+    assert.equal(rectHitboxesOverlap(a, b), false)
+})
+
+test('rectHitboxesOverlap: touching edges counts as overlap (inclusive)', () => {
+    const a = { position: { x: 0, y: 0 }, width: 10, height: 10 }
+    const b = { position: { x: 10, y: 0 }, width: 10, height: 10 }
+    assert.equal(rectHitboxesOverlap(a, b), true)
+})
+
+test('rectHitboxesOverlap: full overlap', () => {
+    const a = { position: { x: 5, y: 5 }, width: 20, height: 20 }
+    const b = { position: { x: 10, y: 10 }, width: 5, height: 5 }
+    assert.equal(rectHitboxesOverlap(a, b), true)
+})
+
+test('cannotTakeContactDamage: true while hitCooldown (no repeated damage)', () => {
+    assert.equal(cannotTakeContactDamage({ dead: false, hitCooldown: true }), true)
+})
+
+test('cannotTakeContactDamage: true when dead', () => {
+    assert.equal(cannotTakeContactDamage({ dead: true, hitCooldown: false }), true)
+})
+
+test('cannotTakeContactDamage: false when alive and not on cooldown', () => {
+    assert.equal(cannotTakeContactDamage({ dead: false, hitCooldown: false }), false)
+})
+
+test('contactKnockbackVelocityX: pushes left when player center is left of enemy', () => {
+    const playerHitbox = { position: { x: 0, y: 0 }, width: 10, height: 10 }
+    const enemyHitbox = { position: { x: 100, y: 0 }, width: 10, height: 10 }
+    assert.equal(contactKnockbackVelocityX(playerHitbox, enemyHitbox, 10), -10)
+})
+
+test('contactKnockbackVelocityX: pushes right when player center is right of enemy', () => {
+    const playerHitbox = { position: { x: 200, y: 0 }, width: 10, height: 10 }
+    const enemyHitbox = { position: { x: 0, y: 0 }, width: 10, height: 10 }
+    assert.equal(contactKnockbackVelocityX(playerHitbox, enemyHitbox, 10), 10)
+})
+
+test('contactKnockbackVelocityX: aligned centers picks non-negative branch (>= enemy)', () => {
+    const playerHitbox = { position: { x: 0, y: 0 }, width: 10, height: 10 }
+    const enemyHitbox = { position: { x: 0, y: 0 }, width: 10, height: 10 }
+    assert.equal(contactKnockbackVelocityX(playerHitbox, enemyHitbox, 7), 7)
+})


### PR DESCRIPTION
Fixes #6

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-6-add-lightweight-tests-for-contact-damage-helpers`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #6

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/6
**State:** OPEN
**Title:** Add lightweight tests for contact-damage helpers (overlap, cooldown, knockback)

## Body
## Parent

#1

## What to build

Add a minimal automated test setup for the pure parts of the contact-damage system (rectangle overlap predicate, cooldown gating, knockback direction selection). Keep it lightweight and runnable locally (no browser required).

## Acceptance criteria

- [ ] A simple test command exists (e.g. `node --test` and/or `npm test`) that can be run locally.
- [ ] Tests cover: overlap detection (rect vs rect), cooldown gating (no repeated damage), and knockback direction (push away from enemy).
- [ ] Tests are deterministic and do not depend on animation timing or rendering.

## Blocked by

- Blocked by #2