### PR TITLE
fix: wait for active sprite image before draw (enemies on cold load)

### DIFF
--- a/js/classes/Sprite.js
+++ b/js/classes/Sprite.js
@@ -59,6 +59,13 @@ class Sprite {
 
     draw(scale = 1) {
         if (!this.loaded || this.opacity <= 0) return
+        // After switchSprite(), this.image may point at a different sheet than the one
+        // that fired the constructor onload. Wait for the active image and size the
+        // crop from it so enemies (fall/jump/attack, etc.) render on a cold cache load.
+        if (!this.image.complete || this.image.naturalWidth === 0) return
+
+        this.width = this.image.naturalWidth / this.frameRate
+        this.height = this.image.naturalHeight
 
         const cropbox = {
             position: {


### PR DESCRIPTION
Sprite.loaded was tied to the constructor default image, but Enemy (and Player) switch this.image to animation sheets that load asynchronously. On first load, fall/jump could be incomplete while draw used stale width/height from idle, so nothing appeared until images were cached (e.g. after restart). Draw now skips until the current image is decoded and sizes the crop from naturalWidth/naturalHeight.

Made-with: Cursor