### PR TITLE
fix: Bug: Restart after death leaves player at 2 HP (#18)

### DIFF
--- a/index.js
+++ b/index.js
@@ -549,7 +549,8 @@ window.restartFromGameOver = async () => {
         player.dead = false
         player.hitpoints = 3
         player.preventInput = false
-        player.hitCooldown = false
+        // Old level is still active until createAssets() resolves; stay invulnerable.
+        player.hitCooldown = true
         player.isShowingHello = false
         if (player.contactDamageTimeoutId) {
             clearTimeout(player.contactDamageTimeoutId)


### PR DESCRIPTION
Fixes #18

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-18-bug-restart-after-death-leaves-player-at-2-hp`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #18

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/18
**State:** OPEN
**Labels:** bug
**Title:** Bug: Restart after death leaves player at 2 HP

## Body
## Bug
After the player dies (HP reaches 0) and restarts, the player often starts with **2 HP** instead of **3 HP**.

## Steps to reproduce
1. Take damage until you die (Game Over).
2. Press **R** to restart.
3. Observe the heart UI / HP state immediately after restart.

## Expected
Player restarts with **3 HP** (3 hearts).

## Actual
Player restarts with **2 HP** (2 hearts).

## Notes / likely cause
`window.restartFromGameOver` resets HP/hearts, but it also clears `gameOver`, `dead`, and `hitCooldown` **before** awaiting `initLevel(...)`:

- `index.js`:
  - sets `player.hitpoints = 3` + `resetHearts()`
  - sets `player.gameOver = false`, `player.dead = false`, `player.hitCooldown = false`
  - then `await initLevel(level, ...)`

`initLevel` ultimately calls `loadAssets(...)`, which uses `fetch(...)` and is async (`js/data/parseAssets.js`). While the async level load is in progress, the game loop can run at least one frame with the old world still active, and the player is no longer protected by `dead/hitCooldown`.

If the player died while overlapping an enemy/hazard, `Player.checkEnemyContactDamage()` can immediately call `loseHP()` once during this window, popping a heart and leaving the player at 2 HP.

## Fix ideas
- Keep gameplay "paused" during restart until `initLevel` completes (e.g. a `gameState === 'loading'` gate in `animate()` / `Player.update()`).
- Alternatively, keep `player.hitCooldown = true` (or `dead/gameOver`) until after `initLevel` resolves and the player is repositioned.
- Another low-impact option: add short invulnerability on restart/spawn (e.g. 500–1000ms).