### PR TITLE
feat: Add random movement to pig enemies (exclude king + match) (#20)

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,10 @@
   <script defer src="js/classes/Player.js"></script>
   <script defer src="js/classes/Cannon.js"></script>
   <script defer src="js/classes/CannonBall.js"></script>
+  <script type="module">
+    import * as pigWanderAiCore from './js/pigWanderAiCore.mjs'
+    globalThis.pigWanderAiCore = pigWanderAiCore
+  </script>
   <script defer src="js/classes/Enemy.js"></script>
   <script defer src="js/classes/DialogBox.js"></script>
   <script defer src="js/classes/Diamond.js"></script>

--- a/js/classes/Enemy.js
+++ b/js/classes/Enemy.js
@@ -16,6 +16,69 @@ class Enemy extends Sprite {
         this.collisionBlocks = collisionBlocks
 
         this.attackInterval = setInterval(() => this.attack(), 3000);
+
+        if (enemyVariant === 'pig') {
+            this.pigWalkSpeed = 1
+            this.aiMode = 'idle'
+            this.aiNextDecisionAt = Date.now() + 500 + Math.random() * 1500
+        }
+    }
+
+    pigAiDeferDecision(ms) {
+        this.aiNextDecisionAt = Date.now() + ms
+    }
+
+    pigPickNextBehavior() {
+        const r = Math.random()
+        if (r < 0.1) {
+            this.jump()
+            this.velocity.x = 0
+            this.aiMode = 'idle'
+            this.pigAiDeferDecision(700 + Math.random() * 900)
+            return
+        }
+        const r2 = Math.random()
+        if (r2 < 0.38) {
+            this.aiMode = 'idle'
+            this.velocity.x = 0
+            this.flip = false
+            this.switchSprite('idle')
+        } else if (r2 < 0.69) {
+            this.aiMode = 'walkLeft'
+            this.velocity.x = -this.pigWalkSpeed
+            this.flip = false
+            this.switchSprite('runLeft')
+        } else {
+            this.aiMode = 'walkRight'
+            this.velocity.x = this.pigWalkSpeed
+            this.flip = true
+            this.switchSprite('runLeft')
+        }
+        this.pigAiDeferDecision(500 + Math.random() * 1500)
+    }
+
+    pigTickAi() {
+        if (this.enemyVariant !== 'pig') return
+        if (this.playerHit || this.hitpoints <= 0 || this.attacking) {
+            this.velocity.x = 0
+            return
+        }
+        let grounded = Math.abs(this.velocity.y) < 0.15
+        if (Date.now() >= this.aiNextDecisionAt) {
+            if (grounded) this.pigPickNextBehavior()
+            else this.pigAiDeferDecision(200)
+        }
+        grounded = Math.abs(this.velocity.y) < 0.15
+        if (grounded && !this.attacking && !this.playerHit) {
+            if (Math.abs(this.velocity.x) > 0.01) {
+                this.switchSprite('runLeft')
+                this.flip = this.velocity.x > 0
+            } else {
+                this.aiMode = 'idle'
+                this.flip = false
+                this.switchSprite('idle')
+            }
+        }
     }
 
     move(runSpeed = -1) {
@@ -85,6 +148,7 @@ class Enemy extends Sprite {
         if (this.state === 'matchOn') return
         if (!this.attacking && this.hitpoints > 0 && !this.playerHit) {
             this.attacking = true;
+            if (this.enemyVariant === 'pig') this.velocity.x = 0
             this.switchSprite('attack');
 
             if (this.currentAnimation) {
@@ -120,6 +184,7 @@ class Enemy extends Sprite {
         // debug position
         /*  c.fillStyle = 'rgba(0,0,255,0.3)'
          c.fillRect(this.position.x,this.position.y,this.width,this.height)   */
+        this.pigTickAi()
         this.position.x += this.velocity.x
 
         this.updateHitbox()
@@ -178,13 +243,25 @@ class Enemy extends Sprite {
                 if (this.velocity.x < 0) {
                     const offset = this.hitbox.position.x - this.position.x
                     this.position.x = collisionBlock.position.x + collisionBlock.width - offset + 0.01
-                    if (!this.attacking) this.switchSprite('idle')
+                    if (this.enemyVariant === 'pig' && !this.attacking && !this.playerHit && this.hitpoints > 0) {
+                        this.velocity.x = this.pigWalkSpeed
+                        this.flip = true
+                        this.switchSprite('runLeft')
+                        this.aiMode = 'walkRight'
+                        this.pigAiDeferDecision(300 + Math.random() * 500)
+                    } else if (!this.attacking) this.switchSprite('idle')
                     break
                 }
                 if (this.velocity.x > 0) {
                     const offset = this.hitbox.position.x - this.position.x + this.hitbox.width
                     this.position.x = collisionBlock.position.x - offset - 0.01
-                    if (!this.attacking) this.switchSprite('idle')
+                    if (this.enemyVariant === 'pig' && !this.attacking && !this.playerHit && this.hitpoints > 0) {
+                        this.velocity.x = -this.pigWalkSpeed
+                        this.flip = false
+                        this.switchSprite('runLeft')
+                        this.aiMode = 'walkLeft'
+                        this.pigAiDeferDecision(300 + Math.random() * 500)
+                    } else if (!this.attacking) this.switchSprite('idle')
                     break
                 }
 

--- a/js/classes/Enemy.js
+++ b/js/classes/Enemy.js
@@ -21,6 +21,7 @@ class Enemy extends Sprite {
             this.pigWalkSpeed = 1
             this.aiMode = 'idle'
             this.aiNextDecisionAt = Date.now() + 500 + Math.random() * 1500
+            this.pigWallSteerUntil = 0
         }
     }
 
@@ -29,56 +30,63 @@ class Enemy extends Sprite {
     }
 
     pigPickNextBehavior() {
-        const r = Math.random()
-        if (r < 0.1) {
+        const core = globalThis.pigWanderAiCore
+        if (!core) return
+        const plan = core.planBehavior(Math.random(), Math.random(), Math.random(), this.pigWalkSpeed)
+        if (plan.kind === 'jump') {
             this.jump()
             this.velocity.x = 0
-            this.aiMode = 'idle'
-            this.pigAiDeferDecision(700 + Math.random() * 900)
+            this.aiMode = core.PIG_AI_STATES.IDLE
+            this.pigAiDeferDecision(plan.nextDelayMs)
             return
         }
-        const r2 = Math.random()
-        if (r2 < 0.38) {
-            this.aiMode = 'idle'
-            this.velocity.x = 0
-            this.flip = false
-            this.switchSprite('idle')
-        } else if (r2 < 0.69) {
-            this.aiMode = 'walkLeft'
-            this.velocity.x = -this.pigWalkSpeed
-            this.flip = false
-            this.switchSprite('runLeft')
-        } else {
-            this.aiMode = 'walkRight'
-            this.velocity.x = this.pigWalkSpeed
-            this.flip = true
-            this.switchSprite('runLeft')
-        }
-        this.pigAiDeferDecision(500 + Math.random() * 1500)
+        this.aiMode = plan.aiMode
+        this.velocity.x = plan.velocityX
+        this.flip = plan.flip
+        this.switchSprite(plan.sprite)
+        this.pigAiDeferDecision(plan.nextDelayMs)
     }
 
     pigTickAi() {
-        if (this.enemyVariant !== 'pig') return
-        if (this.playerHit || this.hitpoints <= 0 || this.attacking) {
+        const core = globalThis.pigWanderAiCore
+        if (!core || !core.isPigWanderEnemy(this)) return
+
+        if (this.playerHit || this.hitpoints <= 0) {
             this.velocity.x = 0
             return
         }
-        let grounded = Math.abs(this.velocity.y) < 0.15
-        if (Date.now() >= this.aiNextDecisionAt) {
-            if (grounded) this.pigPickNextBehavior()
-            else this.pigAiDeferDecision(200)
+
+        const inAttack =
+            this.attacking ||
+            (this.animations &&
+                this.animations.attack &&
+                this.currentAnimation === this.animations.attack)
+
+        if (inAttack) {
+            this.velocity.x = 0
+            return
         }
-        grounded = Math.abs(this.velocity.y) < 0.15
-        if (grounded && !this.attacking && !this.playerHit) {
-            if (Math.abs(this.velocity.x) > 0.01) {
-                this.switchSprite('runLeft')
-                this.flip = this.velocity.x > 0
+
+        const now = Date.now()
+        let grounded = core.isGroundedVerticalVelocity(this.velocity.y)
+
+        if (now >= this.aiNextDecisionAt) {
+            if (!grounded) {
+                this.pigAiDeferDecision(200)
+            } else if (now < this.pigWallSteerUntil) {
+                this.pigAiDeferDecision(Math.max(50, this.pigWallSteerUntil - now + 20))
             } else {
-                this.aiMode = 'idle'
-                this.flip = false
-                this.switchSprite('idle')
+                this.pigPickNextBehavior()
             }
         }
+
+        grounded = core.isGroundedVerticalVelocity(this.velocity.y)
+        if (!grounded) return
+
+        const sync = core.syncSpriteFromHorizontalVelocity(this.velocity.x, this.pigWalkSpeed)
+        this.switchSprite(sync.sprite)
+        this.flip = sync.flip
+        if (sync.aiMode) this.aiMode = sync.aiMode
     }
 
     move(runSpeed = -1) {
@@ -243,24 +251,30 @@ class Enemy extends Sprite {
                 if (this.velocity.x < 0) {
                     const offset = this.hitbox.position.x - this.position.x
                     this.position.x = collisionBlock.position.x + collisionBlock.width - offset + 0.01
-                    if (this.enemyVariant === 'pig' && !this.attacking && !this.playerHit && this.hitpoints > 0) {
-                        this.velocity.x = this.pigWalkSpeed
-                        this.flip = true
-                        this.switchSprite('runLeft')
-                        this.aiMode = 'walkRight'
-                        this.pigAiDeferDecision(300 + Math.random() * 500)
+                    const core = globalThis.pigWanderAiCore
+                    if (core && core.isPigWanderEnemy(this) && !this.attacking && !this.playerHit && this.hitpoints > 0) {
+                        const r = core.responseAfterLeftWallCollision(this.pigWalkSpeed)
+                        this.velocity.x = r.velocityX
+                        this.flip = r.flip
+                        this.switchSprite(r.sprite)
+                        this.aiMode = r.aiMode
+                        this.pigWallSteerUntil = core.wallSteerUntilFromNow(Date.now(), Math.random())
+                        this.aiNextDecisionAt = Math.max(this.aiNextDecisionAt, this.pigWallSteerUntil + 20)
                     } else if (!this.attacking) this.switchSprite('idle')
                     break
                 }
                 if (this.velocity.x > 0) {
                     const offset = this.hitbox.position.x - this.position.x + this.hitbox.width
                     this.position.x = collisionBlock.position.x - offset - 0.01
-                    if (this.enemyVariant === 'pig' && !this.attacking && !this.playerHit && this.hitpoints > 0) {
-                        this.velocity.x = -this.pigWalkSpeed
-                        this.flip = false
-                        this.switchSprite('runLeft')
-                        this.aiMode = 'walkLeft'
-                        this.pigAiDeferDecision(300 + Math.random() * 500)
+                    const core = globalThis.pigWanderAiCore
+                    if (core && core.isPigWanderEnemy(this) && !this.attacking && !this.playerHit && this.hitpoints > 0) {
+                        const r = core.responseAfterRightWallCollision(this.pigWalkSpeed)
+                        this.velocity.x = r.velocityX
+                        this.flip = r.flip
+                        this.switchSprite(r.sprite)
+                        this.aiMode = r.aiMode
+                        this.pigWallSteerUntil = core.wallSteerUntilFromNow(Date.now(), Math.random())
+                        this.aiNextDecisionAt = Math.max(this.aiNextDecisionAt, this.pigWallSteerUntil + 20)
                     } else if (!this.attacking) this.switchSprite('idle')
                     break
                 }
@@ -300,7 +314,7 @@ class Enemy extends Sprite {
         }
     }
     applyGravity() {
-        if (this.velocity.y > 0 && this.hitpoints !== 0 && !this.playerHit) {
+        if (this.velocity.y > 0 && this.hitpoints !== 0 && !this.playerHit && !this.attacking) {
             this.switchSprite('fall');
         }
         this.velocity.y += this.gravity;

--- a/js/pigWanderAiCore.mjs
+++ b/js/pigWanderAiCore.mjs
@@ -1,0 +1,103 @@
+/** Pig wander AI: pure helpers + state names (used by Enemy.js and node tests). */
+
+export const PIG_AI_STATES = Object.freeze({
+    IDLE: 'idle',
+    WALK_LEFT: 'walkLeft',
+    WALK_RIGHT: 'walkRight',
+})
+
+/** After a wall bounce, AI must not pick a new random mode until this window ends. */
+export const WALL_STEER_MS = 280
+
+/** Extra random delay layered on wall steer (matches previous collision behavior). */
+export function wallSteerUntilFromNow(now, rng01) {
+    return now + WALL_STEER_MS + rng01 * 500
+}
+
+export function isPigWanderEnemy(e) {
+    return Boolean(e && e.enemyVariant === 'pig' && Number.isFinite(e.pigWalkSpeed))
+}
+
+export function isGroundedVerticalVelocity(velocityY) {
+    return Math.abs(velocityY) < 0.15
+}
+
+/**
+ * @param {number} r1 - jump roll [0,1)
+ * @param {number} r2 - walk mode roll [0,1) (also scales jump delay tail)
+ * @param {number} r3 - next decision delay roll [0,1)
+ * @param {number} pigWalkSpeed
+ */
+export function planBehavior(r1, r2, r3, pigWalkSpeed) {
+    if (r1 < 0.1) {
+        return {
+            kind: 'jump',
+            nextDelayMs: 700 + r2 * 900,
+        }
+    }
+    const nextDelayMs = 500 + r3 * 1500
+    if (r2 < 0.38) {
+        return {
+            kind: 'walk',
+            aiMode: PIG_AI_STATES.IDLE,
+            velocityX: 0,
+            flip: false,
+            sprite: 'idle',
+            nextDelayMs,
+        }
+    }
+    if (r2 < 0.69) {
+        return {
+            kind: 'walk',
+            aiMode: PIG_AI_STATES.WALK_LEFT,
+            velocityX: -pigWalkSpeed,
+            flip: false,
+            sprite: 'runLeft',
+            nextDelayMs,
+        }
+    }
+    return {
+        kind: 'walk',
+        aiMode: PIG_AI_STATES.WALK_RIGHT,
+        velocityX: pigWalkSpeed,
+        flip: true,
+        sprite: 'runLeft',
+        nextDelayMs,
+    }
+}
+
+/** Grounded movement: which sprite / flip to show (does not override attack / hit). */
+export function syncSpriteFromHorizontalVelocity(velocityX, pigWalkSpeed) {
+    if (Math.abs(velocityX) > 0.01) {
+        return {
+            sprite: 'runLeft',
+            flip: velocityX > 0,
+            aiMode: null,
+        }
+    }
+    return {
+        sprite: 'idle',
+        flip: false,
+        aiMode: PIG_AI_STATES.IDLE,
+    }
+}
+
+/** Physics flipped us away from a wall while moving left into it. */
+export function responseAfterLeftWallCollision(pigWalkSpeed) {
+    return {
+        velocityX: pigWalkSpeed,
+        flip: true,
+        sprite: 'runLeft',
+        aiMode: PIG_AI_STATES.WALK_RIGHT,
+    }
+}
+
+/** Physics flipped us away from a wall while moving right into it. */
+export function responseAfterRightWallCollision(pigWalkSpeed) {
+    return {
+        velocityX: -pigWalkSpeed,
+        flip: false,
+        sprite: 'runLeft',
+        aiMode: PIG_AI_STATES.WALK_LEFT,
+    }
+}

--- a/test/pigWanderAiCore.test.mjs
+++ b/test/pigWanderAiCore.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+import {
+    PIG_AI_STATES,
+    isGroundedVerticalVelocity,
+    isPigWanderEnemy,
+    planBehavior,
+    responseAfterLeftWallCollision,
+    responseAfterRightWallCollision,
+    syncSpriteFromHorizontalVelocity,
+    wallSteerUntilFromNow,
+    WALL_STEER_MS,
+} from '../js/pigWanderAiCore.mjs'
+
+test('isPigWanderEnemy: standard pig with walk speed', () => {
+    assert.equal(isPigWanderEnemy({ enemyVariant: 'pig', pigWalkSpeed: 1 }), true)
+})
+
+test('isPigWanderEnemy: king and match are excluded (no wander fields)', () => {
+    assert.equal(isPigWanderEnemy({ enemyVariant: 'king', pigWalkSpeed: undefined }), false)
+    assert.equal(isPigWanderEnemy({ enemyVariant: 'match', pigWalkSpeed: undefined }), false)
+})
+
+test('isPigWanderEnemy: pig without pigWalkSpeed is excluded (guard for non-standard variants)', () => {
+    assert.equal(isPigWanderEnemy({ enemyVariant: 'pig' }), false)
+    assert.equal(isPigWanderEnemy({ enemyVariant: 'pig', pigWalkSpeed: NaN }), false)
+})
+
+test('planBehavior: over many decisions yields idle, both walks, and jumps (wandering variety)', () => {
+    const kinds = new Set()
+    let i = 0
+    while (i < 400 && kinds.size < 4) {
+        const r1 = (i % 97) / 97
+        const r2 = (i % 89) / 89
+        const r3 = (i % 83) / 83
+        const p = planBehavior(r1, r2, r3, 1)
+        kinds.add(p.kind === 'jump' ? 'jump' : p.aiMode)
+        i++
+    }
+    assert.ok(kinds.has(PIG_AI_STATES.IDLE))
+    assert.ok(kinds.has(PIG_AI_STATES.WALK_LEFT))
+    assert.ok(kinds.has(PIG_AI_STATES.WALK_RIGHT))
+    assert.ok(kinds.has('jump'))
+})
+
+test('wall bounce responses are opposite horizontal speeds (symmetric magnitudes)', () => {
+    const speed = 1.25
+    const leftHit = responseAfterLeftWallCollision(speed)
+    const rightHit = responseAfterRightWallCollision(speed)
+    assert.equal(leftHit.velocityX, speed)
+    assert.equal(rightHit.velocityX, -speed)
+    assert.equal(leftHit.velocityX, -rightHit.velocityX)
+    assert.equal(leftHit.aiMode, PIG_AI_STATES.WALK_RIGHT)
+    assert.equal(rightHit.aiMode, PIG_AI_STATES.WALK_LEFT)
+})
+
+test('wallSteerUntilFromNow is always in the future and bounded', () => {
+    const now = 1_000_000
+    const t0 = wallSteerUntilFromNow(now, 0)
+    const t1 = wallSteerUntilFromNow(now, 1)
+    assert.ok(t0 >= now + WALL_STEER_MS)
+    assert.ok(t1 <= now + WALL_STEER_MS + 500 + 1e-6)
+    assert.ok(t1 >= t0)
+})
+
+test('syncSpriteFromHorizontalVelocity: maps velocity to runLeft + flip or idle', () => {
+    const m = syncSpriteFromHorizontalVelocity(0.5, 1)
+    assert.equal(m.sprite, 'runLeft')
+    assert.equal(m.flip, true)
+    const idle = syncSpriteFromHorizontalVelocity(0, 1)
+    assert.equal(idle.sprite, 'idle')
+    assert.equal(idle.flip, false)
+    assert.equal(idle.aiMode, PIG_AI_STATES.IDLE)
+})
+
+test('isGroundedVerticalVelocity matches Enemy threshold', () => {
+    assert.equal(isGroundedVerticalVelocity(0), true)
+    assert.equal(isGroundedVerticalVelocity(0.14), true)
+    assert.equal(isGroundedVerticalVelocity(0.16), false)
+})
+
+test('non-regression: attack() only zeroes velocity.x for pig variant (source guard)', () => {
+    const path = fileURLToPath(new URL('../js/classes/Enemy.js', import.meta.url))
+    const src = readFileSync(path, 'utf8')
+    assert.ok(
+        /if\s*\(\s*this\.enemyVariant\s*===\s*['"]pig['"]\s*\)\s*this\.velocity\.x\s*=\s*0/.test(src),
+        'Expected pig-only velocity clear in attack()'
+    )
+})
+
+test('non-regression: match-specific attack early return unchanged', () => {
+    const path = fileURLToPath(new URL('../js/classes/Enemy.js', import.meta.url))
+    const src = readFileSync(path, 'utf8')
+    assert.ok(
+        /if\s*\(\s*this\.state\s*===\s*['"]matchOn['"]\s*\)\s*return/.test(src),
+        'Expected matchOn guard at start of attack()'
+    )
+})


### PR DESCRIPTION
Fixes #20

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-20-add-random-movement-to-pig-enemies-exclude-king-`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #20

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/20
**State:** OPEN
**Labels:** enhancement
**Title:** Add random movement to pig enemies (exclude king + match)

## Body
## Summary
Make standard pig enemies move with simple random/patrol behavior so they don’t feel static.

**Do not change** movement/behavior for:
- King Pig enemies (`enemyVariant: 'king'`)
- Pig-with-match enemies (`enemyVariant: 'match'`)

## Current behavior
`Enemy` instances have velocity and collision/gravity, but they don’t initiate movement on their own (no AI loop besides periodic `attack()` via `attackInterval`).

- `js/classes/Enemy.js`: `update()` applies `velocity.x` and gravity, but nothing sets `velocity.x` unless `move(...)` is called externally.

## Desired behavior (pigs only)
For `enemyVariant === 'pig'`:
- Randomly choose between **idle**, **walk left**, **walk right**.
- Occasionally **change direction** (even without hitting a wall).
- Optional: small chance to **jump** if grounded (keep it subtle).
- Ensure movement respects collisions (existing collision checks already stop horizontal penetration).

## Constraints
- King and match variants should keep their current behavior.
- Don’t break existing animations (use existing `idle`, `runLeft`, `jump`, `fall` where available).
- Keep CPU cost low (no per-frame RNG churn; use timers / next-decision timestamps).

## Implementation ideas
- In `Enemy` constructor, only for pigs:
  - Add AI state fields like `aiNextDecisionAt`, `aiDirection`, `aiMode`.
- In `Enemy.update()`, for pigs:
  - If `Date.now() >= aiNextDecisionAt`, pick a new mode/direction and set next decision time (e.g. 500–2000ms).
  - Set `velocity.x` based on mode; set sprite to `runLeft` when moving, `idle` when stopped.
  - If horizontal collision clamps position (existing code), optionally flip direction and set a short cooldown before next flip.

## Acceptance criteria
- Pig enemies visibly wander/patrol with non-deterministic timing.
- King + match enemies behave exactly as before.
- No new console errors.

## Test plan
- Load a level with multiple pigs.
- Observe that pigs move with varied pauses/directions.
- Verify king pig stays as-is; match enemy stays as-is and still triggers cannon behavior.