### PR TITLE
fix: Bug: Getting hit during attack can softlock player (slides … (#22)

### DIFF
--- a/js/classes/Player.js
+++ b/js/classes/Player.js
@@ -306,6 +306,8 @@ class Player extends Sprite {
     }
 
     takeContactDamageFromEnemy(enemyForKnockback) {
+        this.action = false
+        this.attacking = false
         this.hitCooldown = true
         playHitSound()
         this.switchSprite('hit')
@@ -325,6 +327,9 @@ class Player extends Sprite {
             this.contactDamageTimeoutId = setTimeout(() => {
                 this.contactDamageTimeoutId = null
                 this.hitCooldown = false
+                if (!this.dead) {
+                    this.velocity.x = 0
+                }
                 if (!this.dead && !this.action && !this.attacking) {
                     if (this.lastDirection === 'right') this.switchSprite('idleRight')
                     else this.switchSprite('idleLeft')


### PR DESCRIPTION
Fixes #22

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-22-bug-getting-hit-during-attack-can-softlock-playe`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #22

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/22
**State:** OPEN
**Labels:** bug
**Title:** Bug: Getting hit during attack can softlock player (slides left, no input)

## Body
## Bug
Sometimes if the player is hit by an enemy **while attacking**, the character starts sliding left and becomes unplayable (appears stuck/softlocked).

## Steps to reproduce (suggested)
1. Get close enough to a pig enemy that contact damage can occur.
2. Press/hold **Space** to attack.
3. While the attack is in progress, let the enemy overlap the player (contact damage triggers).
4. Observe the player sometimes gets knocked back and then:
   - keeps sliding left
   - can’t respond to input (movement/attack/jump)

## Expected
- Taking damage during an attack should interrupt the attack cleanly.
- Player regains control after hit cooldown.
- Player knockback should decay/stop.

## Actual
- Player can enter a stuck state (no controls) and continues drifting/sliding.

## Likely root cause
`Player.attack()` sets `this.action = true` and `this.attacking = true` and relies on a custom `currentAnimation.onComplete` callback to clear them:
- `this.currentAnimation = { onComplete: () => { ... this.action=false; this.attacking=false; ... } }`

But when contact damage happens mid-attack, `takeContactDamageFromEnemy()` calls `this.switchSprite('hit')`, which replaces `this.currentAnimation` with the hit animation object.
That prevents the attack `onComplete` from ever firing, leaving `action/attacking` stuck `true`.

Once `action` is stuck true, `handleInput()` returns early (`if (this.preventInput || this.action) return;`), so:
- input is ignored
- `velocity.x` never gets reset to 0 when no keys are pressed

At the same time, contact damage sets knockback velocity (`this.velocity.x = ...`), causing continuous sliding.

## Fix ideas
- On taking contact damage, explicitly cancel attack state:
  - set `this.action = false; this.attacking = false;`
- Ensure knockback stops after cooldown:
  - set `this.velocity.x = 0` at end of hit cooldown (or apply friction)
- Alternative: preserve attack completion semantics even if animation is interrupted (e.g. track attack lifecycle separately from `currentAnimation`).

## Test plan
- Reproduce by forcing contact damage during an attack.
- Verify that after the hit cooldown, player can move/jump/attack normally.
- Verify player does not keep sliding indefinitely.