### PR TITLE
fix: Bug: Hello dialog animation freezes/sticks over player on l… (#23)

### DIFF
--- a/js/classes/Player.js
+++ b/js/classes/Player.js
@@ -47,6 +47,13 @@ class Player extends Sprite {
         helloDialogue.currentAnimation = {
             onComplete: () => {
                 helloDialogue.switchSprite('helloOut')
+                helloDialogue.currentAnimation = {
+                    ...helloDialogue.animations.helloOut,
+                    onComplete: () => {
+                        this.isShowingHello = false
+                        helloDialogue.currentFrame = 0
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #23

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-23-bug-hello-dialog-animation-freezes-sticks-over-p`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #23

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/23
**State:** OPEN
**Labels:** bug
**Title:** Bug: Hello dialog animation freezes/sticks over player on level start

## Body
## Bug
When starting the game (e.g. Level 1 intro), the player’s **Hello** dialog is not rendered properly: it plays and then **freezes/sticks** above the character’s head.

## Steps to reproduce
1. Start the game / enter a level where the intro triggers.
2. Observe the Hello dialog above the player.

## Expected
Hello dialog plays in/out and then disappears.

## Actual
Dialog gets stuck (appears frozen) and remains hovering over the player.

## Notes / likely cause
- `Player.hello()` sets `player.isShowingHello = true` and switches `helloDialogue` to `helloIn`, with an `onComplete` that switches to `helloOut`.
- There is **no code that ever sets `player.isShowingHello` back to false** after `helloOut` finishes.
- `helloOut` is configured with `loop: false`, so it naturally stops on its last frame, which looks like a frozen dialog.

Relevant references:
- `config/ui.js`: `helloDialogue` animations `helloIn` / `helloOut` (both `loop: false`)
- `js/classes/Player.js`: `hello()` sets `isShowingHello = true` and only switches to `helloOut`
- `index.js`: `if (player.isShowingHello) helloDialogue.draw(2)`

## Fix ideas
- After `helloOut` completes, set `player.isShowingHello = false` (and optionally reset `helloDialogue.currentFrame`).
- Implement a second onComplete for `helloOut` (or a timeout) to dismiss the dialog.

## Test plan
- Start Level 1 intro and confirm Hello dialog plays then disappears.
- Trigger `player.hello()` via the `h` key and confirm it dismisses properly.