### PR TITLE
feat: Make Goblin King hittable by player attack (#28)

### DIFF
--- a/js/classes/Player.js
+++ b/js/classes/Player.js
@@ -243,12 +243,17 @@ class Player extends Sprite {
 
     checkEnemyHitCollision() {
         if (this.attacking) {
-            const attackableEnemies = [...enemies, ...enemyKing]
+            const attackableEnemies = [
+                ...(Array.isArray(enemies) ? enemies : []),
+                ...(Array.isArray(enemyKing) ? enemyKing : []),
+            ]
             const attackOverlapsEnemy = (attackBox, enemy) =>
-                attackBox.position.x + attackBox.width >= enemy.hitbox.position.x &&
-                attackBox.position.x <= enemy.hitbox.position.x + enemy.hitbox.width &&
-                attackBox.position.y + attackBox.height >= enemy.hitbox.position.y &&
-                attackBox.position.y <= enemy.hitbox.position.y + enemy.hitbox.height
+                Boolean(
+                    enemy &&
+                    enemy.hitbox &&
+                    typeof enemy.hit === 'function' &&
+                    ContactDamageHelpers.rectHitboxesOverlap(attackBox, enemy.hitbox)
+                )
 
             if (this.lastDirection === 'right') {
                 attackableEnemies.forEach((enemy) => {

--- a/js/classes/Player.js
+++ b/js/classes/Player.js
@@ -243,15 +243,17 @@ class Player extends Sprite {
 
     checkEnemyHitCollision() {
         if (this.attacking) {
+            const attackableEnemies = [...enemies, ...enemyKing]
+            const attackOverlapsEnemy = (attackBox, enemy) =>
+                attackBox.position.x + attackBox.width >= enemy.hitbox.position.x &&
+                attackBox.position.x <= enemy.hitbox.position.x + enemy.hitbox.width &&
+                attackBox.position.y + attackBox.height >= enemy.hitbox.position.y &&
+                attackBox.position.y <= enemy.hitbox.position.y + enemy.hitbox.height
+
             if (this.lastDirection === 'right') {
-                enemies.forEach((enemy) => {
-                    if (this.attackHitboxRight.position.x + this.attackHitboxRight.width >= enemy.hitbox.position.x &&
-                        this.attackHitboxRight.position.x <= enemy.hitbox.position.x + enemy.hitbox.width &&
-                        this.attackHitboxRight.position.y + this.attackHitboxRight.height >= enemy.hitbox.position.y &&
-                        this.attackHitboxRight.position.y <= enemy.hitbox.position.y + enemy.hitbox.height) {
-
+                attackableEnemies.forEach((enemy) => {
+                    if (attackOverlapsEnemy(this.attackHitboxRight, enemy)) {
                         enemy.hit()
-
                     }
                 })
                 boxes.forEach((box) => {
@@ -267,12 +269,8 @@ class Player extends Sprite {
                 })
             }
             else {
-                enemies.forEach((enemy) => {
-                    if (this.attackHitboxLeft.position.x + this.attackHitboxLeft.width >= enemy.hitbox.position.x &&
-                        this.attackHitboxLeft.position.x <= enemy.hitbox.position.x + enemy.hitbox.width &&
-                        this.attackHitboxLeft.position.y + this.attackHitboxLeft.height >= enemy.hitbox.position.y &&
-                        this.attackHitboxLeft.position.y <= enemy.hitbox.position.y + enemy.hitbox.height) {
-
+                attackableEnemies.forEach((enemy) => {
+                    if (attackOverlapsEnemy(this.attackHitboxLeft, enemy)) {
                         enemy.hit()
                     }
                 })

--- a/js/utils.js
+++ b/js/utils.js
@@ -204,6 +204,7 @@ function createEnemyKing(positions, levelNum) {
         frameRate: 12,
         loop: true,
         autoplay: true,
+        // hit / dead / attack / jump / fall: consumed by Enemy base (same hooks as pigs).
         animations: {
             idle: {
                 frameRate: 12,

--- a/js/utils.js
+++ b/js/utils.js
@@ -216,7 +216,35 @@ function createEnemyKing(positions, levelNum) {
                 frameBuffer: 6,
                 loop: true,
                 imageSrc: './Sprites/02-King Pig/Run (38x28).png',
-            }
+            },
+            hit: {
+                frameRate: 2,
+                frameBuffer: 12,
+                loop: false,
+                imageSrc: './Sprites/02-King Pig/Hit (38x28).png',
+            },
+            dead: {
+                frameRate: 4,
+                frameBuffer: 12,
+                loop: false,
+                imageSrc: './Sprites/02-King Pig/Dead (38x28).png',
+            },
+            attack: {
+                frameRate: 5,
+                frameBuffer: 12,
+                loop: false,
+                imageSrc: './Sprites/02-King Pig/Attack (38x28).png',
+            },
+            jump: {
+                frameRate: 1,
+                loop: false,
+                imageSrc: './Sprites/02-King Pig/Jump (38x28).png',
+            },
+            fall: {
+                frameRate: 1,
+                loop: false,
+                imageSrc: './Sprites/02-King Pig/Fall (38x28).png',
+            },
         }
     }))
 }

--- a/test/attackHitOverlap.test.mjs
+++ b/test/attackHitOverlap.test.mjs
@@ -1,0 +1,36 @@
+/**
+ * Player attack vs enemies uses ContactDamageHelpers.rectHitboxesOverlap on each
+ * target hitbox (see Player.checkEnemyHitCollision). These cases mirror king vs pig
+ * hitbox sizes from Enemy.updateHitbox configs.
+ *
+ * Manual check (#28): open a level with an enemyKing layer (e.g. Level 2 in
+ * config/levels.js), attack the Goblin King facing left and right, confirm damage.
+ * Bump the king to confirm contact damage still applies. Confirm pigs still react to swings.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { rectHitboxesOverlap } from '../js/contactDamageHelpers.mjs'
+
+const KING_HITBOX = { position: { x: 124, y: 130 }, width: 38, height: 28 }
+const PIG_HITBOX = { position: { x: 123, y: 130 }, width: 37, height: 28 }
+
+test('attack rect overlaps Goblin King hitbox (right-facing swing)', () => {
+    const attackBox = { position: { x: 100, y: 100 }, width: 65, height: 75 }
+    assert.equal(rectHitboxesOverlap(attackBox, KING_HITBOX), true)
+})
+
+test('attack rect overlaps Goblin King hitbox (left-facing swing)', () => {
+    const attackBox = { position: { x: 80, y: 100 }, width: 65, height: 75 }
+    assert.equal(rectHitboxesOverlap(attackBox, KING_HITBOX), true)
+})
+
+test('attack rect overlaps pig hitbox (same overlap rule as king)', () => {
+    const attackBox = { position: { x: 100, y: 100 }, width: 65, height: 75 }
+    assert.equal(rectHitboxesOverlap(attackBox, PIG_HITBOX), true)
+})
+
+test('attack rect separated from enemy hitbox does not overlap', () => {
+    const attackBox = { position: { x: 0, y: 0 }, width: 65, height: 75 }
+    assert.equal(rectHitboxesOverlap(attackBox, KING_HITBOX), false)
+})


### PR DESCRIPTION
Fixes #28

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-28-make-goblin-king-hittable-by-player-attack`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #28

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/28
**State:** OPEN
**Title:** Make Goblin King hittable by player attack

## Body
## Parent

#27

## What to build

Update combat so the player’s attack can hit/damage the Goblin King using the same attack-hit rules used for normal enemies. After the change, the king is still able to deal contact damage, but the player can retaliate (combat consistency).

## Acceptance criteria

- [ ] When the player attack hitbox overlaps the Goblin King, the king takes damage (same behavior class as other enemies).
- [ ] Contact damage from the king still works (player loses HP on overlap, respecting existing cooldown).
- [ ] Existing enemies (e.g., pigs) remain attackable and behave the same as before.
- [ ] Quick manual verification path exists (e.g., load a level with a king and confirm hit + damage).

## Blocked by

None - can start immediately