### PR TITLE
feat: Menu on ESC (#31)

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
   <script defer src="js/classes/Platform.js"></script>
   <script defer src="js/eventListeners.js"></script>
   <script type="module" src="js/menuGeometry-bootstrap.mjs"></script>
+  <script type="module" src="js/gameFlow-bootstrap.mjs"></script>
   <script defer src="index.js"></script>
   <script defer src="config/ui.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function readStoredSelectedLevel() {
     }
 }
 
+/** High-level flow. Death uses `player.gameOver` while this stays `'playing'`. */
 let gameState = 'menu' // 'menu' | 'loading' | 'playing'
 let selectedLevel = 1
 /** True when the menu was opened with Escape during gameplay (so Escape can resume). */
@@ -334,20 +335,19 @@ function canvasClickCoords(e) {
 }
 
 async function startGame(levelToStart) {
+    const flow = globalThis.__gameFlow
+    if (!flow?.clearHeldInputKeys || !flow?.resetPlayerForNewLevelRun) {
+        console.error('gameFlow-bootstrap.mjs must load before index.js')
+        return
+    }
     pauseMenuFromPlaying = false
     gameState = 'loading'
     player.preventInput = true
     overlay.opacity = 1
     diamondCount = 0
     numberSprites = createNumberSprites(0)
-    player.gameOver = false
-    player.dead = false
-    player.hitpoints = 3
-    player.isShowingHello = false
-    if (player.contactDamageTimeoutId) {
-        clearTimeout(player.contactDamageTimeoutId)
-        player.contactDamageTimeoutId = null
-    }
+    flow.clearHeldInputKeys(keys)
+    flow.resetPlayerForNewLevelRun(player)
     resetHearts()
     EnemyTracker.resetSession()
     enemyNumberSprite = createNumberSprites(EnemyTracker.getEnemyCount(), { x: 50, y: 80 })
@@ -552,10 +552,14 @@ window.restartFromGameOver = async () => {
     if (!player.gameOver || player._restarting) return
     player._restarting = true
     try {
-        keys.w.pressed = false
-        keys.a.pressed = false
-        keys.d.pressed = false
-        keys.space.pressed = false
+        if (globalThis.__gameFlow?.clearHeldInputKeys) {
+            globalThis.__gameFlow.clearHeldInputKeys(keys)
+        } else {
+            keys.w.pressed = false
+            keys.a.pressed = false
+            keys.d.pressed = false
+            keys.space.pressed = false
+        }
         player.gameOver = false
         player.dead = false
         player.hitpoints = 3
@@ -580,35 +584,30 @@ window.restartFromGameOver = async () => {
     }
 }
 
-function clearMovementKeys() {
-    keys.w.pressed = false
-    keys.a.pressed = false
-    keys.d.pressed = false
-    keys.space.pressed = false
-}
-
 // Escape opens/closes the in-game level menu (returns true if handled).
 function handleEscapeMenu() {
-    if (gameState === 'loading') return false
-
-    if (gameState === 'playing') {
-        gameState = 'menu'
+    const flow = globalThis.__gameFlow
+    if (!flow?.reduceEscapeKey) return false
+    const result = flow.reduceEscapeKey({
+        gameState,
+        pauseMenuFromPlaying,
+        playerGameOver: player.gameOver,
+        currentLevel: level,
+    })
+    if (!result.handled) return false
+    if (result.clearKeys) flow.clearHeldInputKeys(keys)
+    if (result.gameState !== undefined) gameState = result.gameState
+    if (result.pauseMenuFromPlaying !== undefined) pauseMenuFromPlaying = result.pauseMenuFromPlaying
+    if (result.selectedLevel !== undefined) {
+        selectedLevel = result.selectedLevel
+        syncMenuSelectionUI()
+    }
+    if (result.playerPreventInput !== undefined) player.preventInput = result.playerPreventInput
+    if (result.resyncMenuSelectionToLevel) {
         selectedLevel = level
         syncMenuSelectionUI()
-        clearMovementKeys()
-        player.preventInput = true
-        pauseMenuFromPlaying = true
-        return true
     }
-
-    if (gameState === 'menu' && pauseMenuFromPlaying) {
-        gameState = 'playing'
-        player.preventInput = false
-        pauseMenuFromPlaying = false
-        return true
-    }
-
-    return false
+    return true
 }
 
 queueMicrotask(() => {

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ function readStoredSelectedLevel() {
 
 let gameState = 'menu' // 'menu' | 'loading' | 'playing'
 let selectedLevel = 1
+/** True when the menu was opened with Escape during gameplay (so Escape can resume). */
+let pauseMenuFromPlaying = false
 
 const MENU = {
     preview: { x: 207, y: 88, w: 610, h: 220 },
@@ -332,11 +334,20 @@ function canvasClickCoords(e) {
 }
 
 async function startGame(levelToStart) {
+    pauseMenuFromPlaying = false
     gameState = 'loading'
     player.preventInput = true
     overlay.opacity = 1
     diamondCount = 0
     numberSprites = createNumberSprites(0)
+    player.gameOver = false
+    player.dead = false
+    player.hitpoints = 3
+    player.isShowingHello = false
+    if (player.contactDamageTimeoutId) {
+        clearTimeout(player.contactDamageTimeoutId)
+        player.contactDamageTimeoutId = null
+    }
     resetHearts()
     EnemyTracker.resetSession()
     enemyNumberSprite = createNumberSprites(EnemyTracker.getEnemyCount(), { x: 50, y: 80 })
@@ -567,6 +578,37 @@ window.restartFromGameOver = async () => {
     } finally {
         player._restarting = false
     }
+}
+
+function clearMovementKeys() {
+    keys.w.pressed = false
+    keys.a.pressed = false
+    keys.d.pressed = false
+    keys.space.pressed = false
+}
+
+// Escape opens/closes the in-game level menu (returns true if handled).
+function handleEscapeMenu() {
+    if (gameState === 'loading') return false
+
+    if (gameState === 'playing') {
+        gameState = 'menu'
+        selectedLevel = level
+        syncMenuSelectionUI()
+        clearMovementKeys()
+        player.preventInput = true
+        pauseMenuFromPlaying = true
+        return true
+    }
+
+    if (gameState === 'menu' && pauseMenuFromPlaying) {
+        gameState = 'playing'
+        player.preventInput = false
+        pauseMenuFromPlaying = false
+        return true
+    }
+
+    return false
 }
 
 queueMicrotask(() => {

--- a/js/escapeMenuLogic.mjs
+++ b/js/escapeMenuLogic.mjs
@@ -1,0 +1,47 @@
+/**
+ * Pure Escape-key handling. Game phases:
+ * - menu: title / level picker (not opened from pause): Escape ignored
+ * - menu + pause overlay (opened from playing): Escape resumes
+ * - loading: Escape ignored (do not interrupt init)
+ * - playing + game over overlay: Escape ignored (R restarts)
+ * - playing: Escape opens menu bound to the current level
+ */
+
+export function reduceEscapeKey({
+    gameState,
+    pauseMenuFromPlaying,
+    playerGameOver,
+    currentLevel,
+}) {
+    if (gameState === 'loading') {
+        return { handled: false, reason: 'loading' }
+    }
+
+    if (gameState === 'playing' && playerGameOver) {
+        return { handled: false, reason: 'gameOver' }
+    }
+
+    if (gameState === 'playing') {
+        return {
+            handled: true,
+            gameState: 'menu',
+            pauseMenuFromPlaying: true,
+            selectedLevel: currentLevel,
+            clearKeys: true,
+            playerPreventInput: true,
+        }
+    }
+
+    if (gameState === 'menu' && pauseMenuFromPlaying) {
+        return {
+            handled: true,
+            gameState: 'playing',
+            pauseMenuFromPlaying: false,
+            clearKeys: true,
+            playerPreventInput: false,
+            resyncMenuSelectionToLevel: true,
+        }
+    }
+
+    return { handled: false, reason: 'noOverlay' }
+}

--- a/js/eventListeners.js
+++ b/js/eventListeners.js
@@ -1,4 +1,11 @@
 window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+        if (typeof handleEscapeMenu === 'function' && handleEscapeMenu()) {
+            event.preventDefault()
+            return
+        }
+    }
+
     if (player.gameOver && (event.key === 'r' || event.key === 'R')) {
         event.preventDefault()
         if (window.restartFromGameOver) window.restartFromGameOver()

--- a/js/gameFlow-bootstrap.mjs
+++ b/js/gameFlow-bootstrap.mjs
@@ -1,0 +1,8 @@
+import { reduceEscapeKey } from './escapeMenuLogic.mjs'
+import { clearHeldInputKeys, resetPlayerForNewLevelRun } from './sessionReset.mjs'
+
+globalThis.__gameFlow = {
+    reduceEscapeKey,
+    clearHeldInputKeys,
+    resetPlayerForNewLevelRun,
+}

--- a/js/sessionReset.mjs
+++ b/js/sessionReset.mjs
@@ -1,0 +1,33 @@
+/**
+ * Central place for clearing per-run / per-level player state so level changes
+ * cannot inherit stale movement, combat timers, or death flags.
+ */
+export function clearHeldInputKeys(keys) {
+    if (!keys || typeof keys !== 'object') return
+    for (const id of Object.keys(keys)) {
+        const entry = keys[id]
+        if (entry && typeof entry === 'object' && 'pressed' in entry) {
+            entry.pressed = false
+        }
+    }
+}
+
+export function resetPlayerForNewLevelRun(player) {
+    player.velocity.x = 0
+    player.velocity.y = 0
+    player.action = false
+    player.attacking = false
+    player.canAttack = true
+    player.running = false
+    player.hitCooldown = false
+    player.canJump = true
+    player.dead = false
+    player.gameOver = false
+    player.isShowingHello = false
+    player._restarting = false
+    player.hitpoints = 3
+    if (player.contactDamageTimeoutId) {
+        clearTimeout(player.contactDamageTimeoutId)
+        player.contactDamageTimeoutId = null
+    }
+}

--- a/test/escapeMenuLogic.test.mjs
+++ b/test/escapeMenuLogic.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { reduceEscapeKey } from '../js/escapeMenuLogic.mjs'
+
+test('Escape during loading is ignored', () => {
+    const r = reduceEscapeKey({
+        gameState: 'loading',
+        pauseMenuFromPlaying: false,
+        playerGameOver: false,
+        currentLevel: 2,
+    })
+    assert.equal(r.handled, false)
+    assert.equal(r.reason, 'loading')
+})
+
+test('Escape during game over does not open menu', () => {
+    const r = reduceEscapeKey({
+        gameState: 'playing',
+        pauseMenuFromPlaying: false,
+        playerGameOver: true,
+        currentLevel: 1,
+    })
+    assert.equal(r.handled, false)
+    assert.equal(r.reason, 'gameOver')
+})
+
+test('Escape during gameplay opens pause menu for current level', () => {
+    const r = reduceEscapeKey({
+        gameState: 'playing',
+        pauseMenuFromPlaying: false,
+        playerGameOver: false,
+        currentLevel: 3,
+    })
+    assert.equal(r.handled, true)
+    assert.equal(r.gameState, 'menu')
+    assert.equal(r.pauseMenuFromPlaying, true)
+    assert.equal(r.selectedLevel, 3)
+    assert.equal(r.clearKeys, true)
+    assert.equal(r.playerPreventInput, true)
+})
+
+test('Escape again resumes from pause menu', () => {
+    const r = reduceEscapeKey({
+        gameState: 'menu',
+        pauseMenuFromPlaying: true,
+        playerGameOver: false,
+        currentLevel: 2,
+    })
+    assert.equal(r.handled, true)
+    assert.equal(r.gameState, 'playing')
+    assert.equal(r.pauseMenuFromPlaying, false)
+    assert.equal(r.clearKeys, true)
+    assert.equal(r.playerPreventInput, false)
+    assert.equal(r.resyncMenuSelectionToLevel, true)
+})
+
+test('Escape on title menu (not from pause) is ignored', () => {
+    const r = reduceEscapeKey({
+        gameState: 'menu',
+        pauseMenuFromPlaying: false,
+        playerGameOver: false,
+        currentLevel: 1,
+    })
+    assert.equal(r.handled, false)
+    assert.equal(r.reason, 'noOverlay')
+})

--- a/test/gameFlow-bootstrap.test.mjs
+++ b/test/gameFlow-bootstrap.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+test('gameFlow-bootstrap wires session + escape helpers onto globalThis.__gameFlow', async () => {
+    delete globalThis.__gameFlow
+    await import('../js/gameFlow-bootstrap.mjs')
+    const flow = globalThis.__gameFlow
+    assert.ok(flow)
+    assert.equal(typeof flow.reduceEscapeKey, 'function')
+    assert.equal(typeof flow.clearHeldInputKeys, 'function')
+    assert.equal(typeof flow.resetPlayerForNewLevelRun, 'function')
+})

--- a/test/menuStartRestart.test.mjs
+++ b/test/menuStartRestart.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+/**
+ * Guards the PR requirement: choosing "Start Game" from the menu must always
+ * run `startGame(...)` (full session reload), not only when `selectedLevel`
+ * differs from `level`. `pauseMenuFromPlaying` must be cleared first so a
+ * paused session cannot leak into the next run.
+ */
+test('menu click handler always calls startGame with selected level (source contract)', async () => {
+    const fs = await import('node:fs/promises')
+    const path = await import('node:path')
+    const url = await import('node:url')
+    const dir = path.dirname(url.fileURLToPath(import.meta.url))
+    const src = await fs.readFile(path.join(dir, '..', 'index.js'), 'utf8')
+    assert.match(
+        src,
+        /canvas\.addEventListener\('click'[\s\S]*?void startGame\(selectedLevel\)/,
+        'Start Game click should invoke startGame(selectedLevel)',
+    )
+    assert.match(
+        src,
+        /async function startGame\(levelToStart\) \{[\s\S]*?pauseMenuFromPlaying = false/,
+        'startGame must clear pauseMenuFromPlaying before loading',
+    )
+})

--- a/test/sessionReset.test.mjs
+++ b/test/sessionReset.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { clearHeldInputKeys, resetPlayerForNewLevelRun } from '../js/sessionReset.mjs'
+
+test('clearHeldInputKeys clears every .pressed entry on the keys bag', () => {
+    const keys = {
+        w: { pressed: true },
+        a: { pressed: true },
+        d: { pressed: false },
+        space: { pressed: true },
+        future: { pressed: true },
+    }
+    clearHeldInputKeys(keys)
+    assert.equal(keys.w.pressed, false)
+    assert.equal(keys.a.pressed, false)
+    assert.equal(keys.d.pressed, false)
+    assert.equal(keys.space.pressed, false)
+    assert.equal(keys.future.pressed, false)
+})
+
+test('resetPlayerForNewLevelRun clears run/combat/death state', () => {
+    let cleared = false
+    const player = {
+        velocity: { x: 4, y: -3 },
+        action: true,
+        attacking: true,
+        canAttack: false,
+        running: true,
+        hitCooldown: true,
+        canJump: false,
+        dead: true,
+        gameOver: true,
+        isShowingHello: true,
+        _restarting: true,
+        hitpoints: 0,
+        contactDamageTimeoutId: setTimeout(() => {}, 9999),
+    }
+    const prevId = player.contactDamageTimeoutId
+    resetPlayerForNewLevelRun(player)
+    assert.equal(player.velocity.x, 0)
+    assert.equal(player.velocity.y, 0)
+    assert.equal(player.action, false)
+    assert.equal(player.attacking, false)
+    assert.equal(player.canAttack, true)
+    assert.equal(player.running, false)
+    assert.equal(player.hitCooldown, false)
+    assert.equal(player.canJump, true)
+    assert.equal(player.dead, false)
+    assert.equal(player.gameOver, false)
+    assert.equal(player.isShowingHello, false)
+    assert.equal(player._restarting, false)
+    assert.equal(player.hitpoints, 3)
+    assert.equal(player.contactDamageTimeoutId, null)
+    clearTimeout(prevId)
+})


### PR DESCRIPTION
Fixes #31

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-31-menu-on-esc`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #31

**Repository:** alexisNorthcoders/Platformer-Game
**URL:** https://github.com/alexisNorthcoders/Platformer-Game/issues/31
**State:** OPEN
**Title:** Menu on ESC

## Body
When player hit Escape key, bring up the menu allowing to change the level. This should trigger a restart of the game.